### PR TITLE
Add Dev Contaner configuration for local development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10.4-slim-buster
+
+RUN apt-get update
+RUN apt-get install -y libsass-dev build-essential libcairo2 git
+

--- a/.devcontainer/LICENSE.txt
+++ b/.devcontainer/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2024 Kento Shimada, Oleg Nenashev, and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// Credits - https://github.com/hitsumabushi845/MkDocs-with-Remote-Containers
+{
+    "name": "Material for MkDocs",
+    "dockerFile": "Dockerfile",
+    "customizations": {
+      "vscode": {
+        // Set *default* container specific settings.json values on container create.
+        "settings": {
+          "terminal.integrated.shell.linux": "/bin/bash",
+          "debug.javascript.usePreview": false
+        },
+        // Add the IDs of extensions you want installed when the container is created.
+        "extensions": [
+          "yzhang.markdown-all-in-one",
+          "redhat.vscode-yaml",
+          "shardulm94.trailing-spaces",
+          "oderwat.indent-rainbow",
+          "msjsdiag.debugger-for-chrome"
+        ],
+      },
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [
+      8000
+    ],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "pip3 install -r .devcontainer/requirements.txt "
+    // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+    //"remoteUser": "vscode"
+  }

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -4,8 +4,8 @@ mergedeep==1.3.4
 mkdocs==1.5.3
 mkdocs-autorefs==0.5.0
 mkdocs-macros-plugin==1.0.5
-mkdocs-material==9.4.5
-mkdocs-material[imaging]==9.4.5
+mkdocs-material==9.5.11
+mkdocs-material[imaging]==9.5.11
 mkdocs-multirepo-plugin==0.6.3
 mkdocs-redirects==1.2.1
 mkdocs-extra-sass-plugin==0.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.10"
      
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r .devcontainer/requirements.txt
     
       - name: Build the docs
         run: mkdocs build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: "3.10"
    
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r .devcontainer/requirements.txt
   
       - name: Build the docs site
         run: mkdocs build

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "mkdocs-serve",
+            "type": "shell",
+            "isBackground": true,
+            "command": "mkdocs serve",
+            "problemMatcher": {
+                "owner": "custom",
+                "pattern": {
+                    "regexp": "^.*(Error|Except).*$"
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".*Building documentation.*",
+                    "endsPattern": ".*Serving on.*"
+                }
+            }
+        },
+        {
+            "label": "mkdocs-stop",
+            "type": "shell",
+            "command": "${command:workbench.action.terminal.kill}"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -36,3 +36,10 @@ See the [Community Resources](https://gradle.org/resources/) for the links to th
 All contributions are welcome!
 If you want to contribute anything to this repository,
 just submit a pull request.
+
+## Credits
+
+- [SHIMADA Kento](https://github.com/hitsumabushi845) -
+ for the DevContainers template:
+ [MkDocs-with-Remote-Containers](https://github.com/hitsumabushi845/MkDocs-with-Remote-Containers),
+ distributed under the [MIT License](.devcontainer/LICENSE.txt)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,19 +16,27 @@ and [Material for MkDocs](https://squidfunk.github.io/mkdocs-material).
 So, it uses the Python technology stack instead of Gradle,
 but on the other hand we're leveraging one of the most powerful documentation engines.
 
+## Preparing the environment
+
+It is possible to deploy the site instance locally or inside a Dev Container.
+
+### Dev Container
+
+This repository includes the Dev Container definition that you can use in Visual Studio Code or in IntelliJ Platform
+to spin up the local development environment.
+
+###  Running locally
+
 Requirements:
 
 - Python3 and PiP (Python's package manager), recent versions
 - Linux, MacOS or Windows WSL-2 environment.
   Windows native may work but it is not tested.
 
-## Preparing the environment
-
-Soon we plan to provide a DevContainer to speedup the process.
 For now, you need to install the dependencies:
 
 ```shell
-pip install -r requirements.txt
+pip install -r .devcontainer/requirements.txt
 mkdocs build
 ```
 


### PR DESCRIPTION
Adds support for portable local development of the website. The implementation is inspired by https://github.com/hitsumabushi845/MkDocs-with-Remote-Containers from @hitsumabushi845 and extended to simplify the use. Later we can deply the devcontainer to GitHub packages to speed it up even more

![image](https://github.com/gradle/community/assets/3000480/d42d5bf9-b8cf-42ac-93c1-a78fccd17c16)
