### PR TITLE
Add GSoC 2024 links to the navbar

### DIFF
--- a/docs/surveys/developer-survey/README.md
+++ b/docs/surveys/developer-survey/README.md
@@ -8,7 +8,7 @@ description: >
 # Gradle Build Tool - Software Developer Survey
 
 The Gradle team is committed to enhancing developer experience,
-as one of the top priorities on the [Gradle Roadmap](../..roadmap/README.md/).
+as one of the top priorities on the [Gradle Roadmap](../../roadmap/README.md/).
 Your feedback is crucial in helping us prioritize our efforts!
 The survey will be open for responses until the end of the year,
 and we intend to make it a recurrent event.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,7 +135,11 @@ nav:
       - Events Overview: events/README.md
       - 2024 Developer Survey: surveys/developer-survey/README.md
       - Hacktoberfest: events/hacktoberfest/README.md
-      - Google Summer of Code: events/gsoc/README.md
+      - Google Summer of Code:
+        - Overview: events/gsoc/README.md
+        - Gradle Build Server - Support for Android projects: events/gsoc/2024/gradle-build-server-android.md
+        - Gradle Build Server - DevX and Language Support in Buildship: events/gsoc/2024/gradle-build-server-devx.md
+        - Declarative Syntax and Enhancements for the Checkstyle Plugin: events/gsoc/2024/checkstyle-plugin.md
   - Resources:
     - Resources: resources/README.md
     - Public Roadmap: roadmap/README.md


### PR DESCRIPTION
Subj. They will be as is for another year or so