### PR TITLE
Fix - SEO metadata for GSoC pages.

### DIFF
--- a/docs/contributing/documentation/README.md
+++ b/docs/contributing/documentation/README.md
@@ -1,5 +1,5 @@
 ---
-title: Contributing to Gradle Documentation
+title: "Contributing to Gradle Documentation"
 description: >
     Documentation is essential part of developer experience for Gradle Build Tool users.
     All contributions are welcome!

--- a/docs/cookbook/CONTRIBUTING.md
+++ b/docs/cookbook/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to the Gradle Cookbook
 
-[![a](https://img.shields.io/badge/slack-%23docs-brightgreen?style=flat&logo=slack)](./contributing/community-slack.md)
+[![a](https://img.shields.io/badge/slack-%23docs-brightgreen?style=flat&logo=slack)](../contributing/community-slack.md)
 
 
 The Gradle Cookbook is under active development.
@@ -19,7 +19,7 @@ A few tips:
 
 - All the pages on this site are written in Markdown.
 - If needed, we have various tools available, such as code templates and macros, and we can add more MkDocs plugins if necessary.
-- The Table of Contents is currently located in [mkdocs.yml](../mkdocs.yml).
+- The Table of Contents is currently located in [mkdocs.yml](../../mkdocs.yml).
 When adding new pages, please update the ToC to ensure they are discoverable.
 
 ### Adding New Categories

--- a/docs/events/gsoc/2023/README.md
+++ b/docs/events/gsoc/2023/README.md
@@ -1,6 +1,13 @@
+---
+title: "Gradle in Google Summer of Code 2023"
+description: >
+  Gradle participated in GSoC 2023 under the umbrella of
+  the Kotlin Foundation.
+---
+
 # Gradle in Google Summer of Code 2023
 
-In the summer of 2023, The Kotlin Foundation sponsored four projects for the Google Summer of Code 2023.
+In the summer of 2023, The [Kotlin Foundation](https://kotlinfoundation.org/) sponsored four projects for the Google Summer of Code 2023.
 The Gradle Kotlin Script Support for Eclipse and BuildShip project by [Nikolai Vladimirov](https://www.linkedin.com/in/vladimir0v/) was one of them!
 Gradle, a Kotlin Foundation member, and [Donát Csikós](https://github.com/donat) provided mentoring support for this project.
 

--- a/docs/events/gsoc/2024/README.md
+++ b/docs/events/gsoc/2024/README.md
@@ -1,3 +1,10 @@
+---
+title: "Gradle in Google Summer of Code 2024"
+description: >
+  Gradle participated in GSoC 2024 under the umbrellas of
+  the Kotlin Foundation and the Eclipse Foundation.
+---
+
 # Gradle in Google Summer of Code 2024
 
 This is an active program.

--- a/docs/events/gsoc/2024/checkstyle-plugin.md
+++ b/docs/events/gsoc/2024/checkstyle-plugin.md
@@ -1,3 +1,10 @@
+---
+title: "Declarative Syntax and enhancements for the Checkstyle plugin"
+description: >
+  A project by Hongjie (Jay) Wei for GSoC 2024 which aims to enhance
+  the declarative nature of Kotlin DSL and enhance the checkstyle plugin.
+---
+
 # GSoC 2024. Declarative Syntax and Enhancements for the Checkstyle Plugin
 
 ## Goal

--- a/docs/events/gsoc/2024/gradle-build-server-android.md
+++ b/docs/events/gsoc/2024/gradle-build-server-android.md
@@ -1,3 +1,10 @@
+---
+title: "Gradle Build Server - support for Android projects"
+description: >
+  A project by Tanish Ranjan for GSoC 2024 which aims to bring support
+  for Android projects on the Gradle Build Server.
+---
+
 # GSoC 2024. Gradle Build Server – support for Android projects
 
 This project aims to enhance [Gradle Build Server](https://github.com/microsoft/build-server-for-gradle) project from Microsoft by integrating powerful Android Studio features. Bridging the build process gap between [Android Studio](https://developer.android.com/studio) and [Gradle Build Server](https://github.com/microsoft/build-server-for-gradle), will significantly improve the development experience for many Android developers using Text Editors/IDEs which utilize the [Build Server Protocol (BSP)](https://build-server-protocol.github.io).

--- a/docs/events/gsoc/2024/gradle-build-server-devx.md
+++ b/docs/events/gsoc/2024/gradle-build-server-devx.md
@@ -1,7 +1,8 @@
 ---
 title: "DevX and Language support in Buildship"
 description: >
-  A project by Sidhaarth Saraswathi Ramalingam for GSoC 2024 which aims to.
+  A project by Sidhaarth Saraswathi Ramalingam for GSoC 2024 which aims to leverage the BSP
+  implementation by the Gradle Build Server in Eclipse IDE via the Eclipse Buildship plugin.
 ---
 
 # GSoC 2024. Gradle Build Server - DevX and Language Support in Buildship
@@ -60,5 +61,4 @@ The Eclipse buildship client will be equipped with capabilities to process all p
 ## Links
 - [Contributor Proposal](https://docs.google.com/document/d/1ptbZvt8_dW0bgUAZfh7m-Oo3RtC4XTiY9frIrf2_OBQ/edit?usp=sharing)
 - [Project Proposal](https://gitlab.eclipse.org/eclipsefdn/emo-team/gsoc-at-the-ef/-/issues/5)
-- [Eclipse Buildship](Placeholder)
-- [Gradle BSP Enhancements](Placeholder)
+- [Eclipse Buildship](https://projects.eclipse.org/projects/tools.buildship)

--- a/docs/events/gsoc/2024/gradle-build-server-devx.md
+++ b/docs/events/gsoc/2024/gradle-build-server-devx.md
@@ -1,3 +1,8 @@
+---
+title: "DevX and Language support in Buildship"
+description: >
+  A project by Sidhaarth Saraswathi Ramalingam for GSoC 2024 which aims to.
+---
 
 # GSoC 2024. Gradle Build Server - DevX and Language Support in Buildship
 

--- a/docs/events/gsoc/README.md
+++ b/docs/events/gsoc/README.md
@@ -1,7 +1,7 @@
 ---
 title: "Gradle in Google Summer of Code"
 description: >
-  Gradle participates in GSoC 2024 under the umbrellas of
+  Gradle participated in GSoC 2024 under the umbrellas of
   the Kotlin Foundation and the Eclipse Foundation.
 ---
 
@@ -13,11 +13,11 @@ Gradle has participated in GSoC since 2023.
 
 ## GSoC 2024
 
-Gradle participates in GSoC 2024 under the umbrellas of
-the Kotlin Foundation and the Eclipse Foundation.
-We started with 3 projects, but two of them didn't pass the mid-term evaluation.
+Gradle participated in GSoC 2024 under the umbrellas of
+the [Kotlin Foundation](https://kotlinfoundation.org/) and the [Eclipse Foundation](https://www.eclipse.org/).
+We started with 3 projects, but two of them didn't pass the midterm evaluation.
 
-Active projects:
+Completed projects:
 
 - [Gradle Build Server – support for Android projects](./2024/gradle-build-server-android.md) by Tanish Ranjan
 
@@ -63,8 +63,8 @@ because it helps us to build impression about the candidate.
 To get started:
 
 1. Join the `#gsoc` channel on the [Gradle community Slack](https://gradle.org/slack-invite).
-  If there're such channels in the foundations, please join them too
-2. Explore the [Getting Started with Gradle](https://docs.gradle.org/current/userguide/getting_started_eng.html) with Gradle and the relevant [topic-specific Gradle Guides](https://gradle.org/guides/)
+  If there are such channels in the foundations, please join them too
+2. Explore the [Getting Started with Gradle](https://docs.gradle.org/current/userguide/getting_started_eng.html) and the relevant [topic-specific Gradle Guides](https://gradle.org/guides/)
 3. Check out the [contributing guidelines](../../contributing/README.md), try addressing some of the newcomer friendly issues
 4. Discuss the project ideas with your mentors on the public channels
 


### PR DESCRIPTION
This PR adds SEO metadata such as title and description to all the GSoC pages.
Fix for issue: https://github.com/gradle/community/issues/100