### PR TITLE
Updated twitter icon

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,7 +92,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/gradle
       name: GitHub
-    - icon: fontawesome/brands/twitter
+    - icon: fontawesome/brands/x-twitter
       link: https://twitter.com/gradle
       name: Twitter/X
     - icon: fontawesome/brands/linkedin


### PR DESCRIPTION
The Twitter logo has been changed and hasn't been updated on this site. [Fixes #112]

<img width="210" alt="Screenshot 2024-10-18 at 8 01 29 PM" src="https://github.com/user-attachments/assets/547cfa2e-fc72-4ac1-8c24-6ba4bd9256aa">
