### PR TITLE
Add quick links to the contributor guide + Plugin contributor stub

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
         },
         // Add the IDs of extensions you want installed when the container is created.
         "extensions": [
+          "streetsidesoftware.code-spell-checker",
           "yzhang.markdown-all-in-one",
           "redhat.vscode-yaml",
           "shardulm94.trailing-spaces",

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,5 +1,6 @@
 Markdown==3.5
 MarkupSafe==2.1.3
+mdx_truly_sane_lists==1.3
 mergedeep==1.3.4
 mkdocs==1.5.3
 mkdocs-autorefs==0.5.0

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -10,16 +10,26 @@ description: >
 As in any open-source project, contributions to Gradle are welcome!
 Gradle Build Tool itself, its documentation, many plugins and tools within Gradle's ecosystem are open-source,
 and you can contribute anywhere.
+Regardless of how much time you can dedicate and your level of expertise,
+there are opportunities to contribute!
+
 See the links on the left for particular contributing guidelines.
+
+## Types of Contribution
+
+* Code Contributions - new features, bug fixes, test automation, etc.
+  * [Contributing to Gradle Build Tool](../gradle/CONTRIBUTING.md) - Contributing to Gradle Build Tool and the core plugins.
+  * [Contributing to Plugins](./plugins.md)
+* [Contributing to Documentation](./documentation/README.md)
+* [Spread the Word](./spread-the-word.md) about Gradle - advocacy, public speaking and sharing your experiences
+* Join community channels, help Gradle users and share your experiences.
 
 ## For Newcomers
 
 If you are a newcomer contributor,
-note that Gradle has a quite steep learning curve.
+note that Gradle Build Tool and core plugins (components under [gradle/gradle](https://github.com/gradle/gradle)) have a quite steep learning curve.
 As the foundational developer tool used by millions,
 there are high expectations about stability and maintainability of the submitted code and documentation.
-The main [gradle/gradle](https://github.com/gradle/gradle)
-has quite strict rules and requirements,
 and it may take a while till your changes are merged and released.
 
 If you are just starting your journey in open source and
@@ -27,14 +37,14 @@ do not aim fixing a specific issue impacting you,
 it is highly recommended to start from plugins and smaller repositories
 where the entry bar is much lower.
 
-## Key Channels
+## Key Communication Channels
 
 ### Community Slack
 
 We have a community Slack on the `gradle-community` workspace.
 This is a main channel for Q&A and quick discussions.
 
-- [Join the Community Slack](https://gradle.org/slack-invite)
+- [Join the Community Slack](./community-slack.md)
 - Use the `#contributing` channel if you need any help with contributing
   changes to gradle and getting them over the line.
 - We have a searchable Slack archive [here](https://www.linen.dev/s/gradle-community).

--- a/docs/contributing/plugins.md
+++ b/docs/contributing/plugins.md
@@ -1,0 +1,45 @@
+---
+title: "Contributing to Gradle Plugins"
+description: >
+  Many Gradle plugins look for contributions!
+---
+
+# Contributing to Gradle Plugins
+
+In this section we focus on [Community Plugins](https://docs.gradle.org/current/userguide/custom_plugins.html#community_plugins)
+which are published on the [Gradle Plugin Portal](https://plugins.gradle.org/).
+
+
+## Contributing to Existing Plugins
+
+Many plugins are open source and can be found on GitHub or Gitlab.
+you can find source code references on the plugin portal.
+For these plugins, you should be able to contribute via pull requests (or merge requests on Gitlab).
+Most of those plugins exist outside the `gradle` organization on GitHub.
+
+On the Gradle Plugin portal, each plugin has an _Owner_ which may represent an individual or an organization.
+These owners fully define the maintenance and contributing policies,
+as well as lifecycle of the components they own.
+Hence, the contributing policy may differ.
+If specified, it can normally be found in `CONTRIBUTING.md` files in the repository.
+
+
+## Creating New Plugins
+
+New Gradle plugins are welcome!
+If you develop a new integration or functionality for Gradle that might be useful to a wider community,
+we encourage you to do it in open source and to publish the plugin on our Plugin Portal.
+
+* [Writing Plugins](https://docs.gradle.org/current/userguide/writing_plugins.html)
+* [Testing Plugins](https://docs.gradle.org/current/userguide/testing_gradle_plugins.html)
+* [Publishing Plugins](https://docs.gradle.org/current/userguide/publishing_gradle_plugins.html)
+
+If you are looking for some Gradle Integration ideas,
+check out the [Integrations Wishlist](https://github.com/gradle/integrations-wishlist)
+
+## References
+
+* [Understanding Plugins](https://docs.gradle.org/current/userguide/custom_plugins.html) -
+  common types pf the plugins.
+* [Gradle Plugin Portal](https://plugins.gradle.org/)
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -204,3 +204,4 @@ markdown_extensions:
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.tasklist:
       custom_checkbox: true
+  - mdx_truly_sane_lists


### PR DESCRIPTION
Just a small update to make the guidelines more discoverable