### PR TITLE
Fix delete preview  comment domain

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -27,10 +27,22 @@ jobs:
 
       - name: Comment on PR
         uses: hasura/comment-progress@v2.2.0
+        if: github.event.pull_request.merged == true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           number: ${{ github.event.number }}
           id: deploy-preview
           message: > 
-            🪓 PR closed, deleted preview at https://${{ env.PREVIEW_DOMAIN}}/${{ env.PREVIEW_REPO }}/tree/gh-pages/${{ env.PPREVIEW_PATH }}/
+            🪓 PR merged, preview deleted ✅ Enjoy the updated content at https://community.gradle.org/
+
+      - name: Comment on PR
+        uses: hasura/comment-progress@v2.2.0
+        if: github.event.pull_request.merged == false
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          number: ${{ github.event.number }}
+          id: deploy-preview
+          message: > 
+            🪓 PR closed, preview deleted ✅

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -33,4 +33,4 @@ jobs:
           number: ${{ github.event.number }}
           id: deploy-preview
           message: > 
-            🪓 PR closed, deleted preview at https://github.com/${{ env.PREVIEW_REPO }}/tree/gh-pages/${{ env.PPREVIEW_PATH }}/
+            🪓 PR closed, deleted preview at https://${{ env.PREVIEW_DOMAIN}}/${{ env.PREVIEW_REPO }}/tree/gh-pages/${{ env.PPREVIEW_PATH }}/

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -32,7 +32,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           number: ${{ github.event.number }}
-          id: deploy-preview
           message: > 
             🪓 PR merged, preview deleted ✅ Enjoy the updated content at https://community.gradle.org/
 
@@ -43,6 +42,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           number: ${{ github.event.number }}
-          id: deploy-preview
           message: > 
             🪓 PR closed, preview deleted ✅


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/preview-cleanup.yml` file. The change updates the URL format in the message for deleting a preview when a pull request is closed.

* [`.github/workflows/preview-cleanup.yml`](diffhunk://#diff-5223b65676c47b22e92043ab7a17c03ad70f3b10a8112a2d8241e2727ebff431L36-R36): Updated the URL format in the `message` field to use `PREVIEW_DOMAIN` for constructing the preview URL.