### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I realized that some actions that are used are outdated.
Like checkout@v3 (v4 is available).
Or the `comment-progress@v2.2.0` (v2.3.0 is available).

Since this is repo is getting more and more into CI/CD stuff, I thought it make sense to add dependabot instead of checking the actions and updating them manually from time to time.