### PR TITLE
Add linke to GradleX project on 'resources/plugins' page

### DIFF
--- a/docs/resources/README.md
+++ b/docs/resources/README.md
@@ -32,6 +32,7 @@ resources:
     - <a href="https://docs.gradle.org/current/userguide/plugin_reference.html">Gradle Core Plugins</a>
     - <a href="https://plugins.gradle.org">Gradle Plugin Portal</a>
     - <a href="https://nebula-plugins.github.io/">Netflix Nebula Collection</a>
+    - <a href="https://gradlex.org/">GradleX</a>
 - section: Contributing
   icon: ../images/icons/contributing.svg
   links:


### PR DESCRIPTION
This links the GradleX project which is a collection of actively developed/maintained Gradle plugins similar to the already linked Nebula.