### PR TITLE
Initialize the 2025 project pages

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -2,11 +2,11 @@ Markdown==3.5
 MarkupSafe==2.1.3
 mdx_truly_sane_lists==1.3
 mergedeep==1.3.4
-mkdocs==1.5.3
+mkdocs==1.6.1
 mkdocs-autorefs==0.5.0
 mkdocs-macros-plugin==1.0.5
 mkdocs-material==9.6.14
-mkdocs-material[imaging]==9.5.17
+mkdocs-material[imaging]==9.6.14
 mkdocs-multirepo-plugin==0.6.3
 mkdocs-redirects==1.2.1
 mkdocs-extra-sass-plugin==0.1.0

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -5,7 +5,7 @@ mergedeep==1.3.4
 mkdocs==1.5.3
 mkdocs-autorefs==0.5.0
 mkdocs-macros-plugin==1.0.5
-mkdocs-material==9.5.17
+mkdocs-material==9.6.14
 mkdocs-material[imaging]==9.5.17
 mkdocs-multirepo-plugin==0.6.3
 mkdocs-redirects==1.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "true"
-      
-      - name: Set up Python
-        uses: actions/setup-python@v5
+
+      - name: Build in the dev container image
+        uses: devcontainers/ci@v0.3
         with:
-          python-version: "3.10"
-     
-      - name: Install dependencies
-        run: pip install -r .devcontainer/requirements.txt
-    
-      - name: Build the docs
-        run: mkdocs build
+          imageName: ghcr.io/gradle/community.gradle.org-builder
+          push: never
+          runCmd: |
+            mkdocs build
+          env: |
+            FULL_BUILD=true
 
       - name: Deploy to PR preview
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,21 +29,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "true"
-      
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v3
-      
-      - name: Set up Python
-        uses: actions/setup-python@v5
+
+      - name: Build in the dev container image
+        uses: devcontainers/ci@v0.3
         with:
-          python-version: "3.10"
-   
-      - name: Install dependencies
-        run: pip install -r .devcontainer/requirements.txt
-  
-      - name: Build the docs site
-        run: mkdocs build
+          imageName: ghcr.io/gradle/community.gradle.org-builder
+          push: never
+          runCmd: |
+            mkdocs build
+          env: |
+            FULL_BUILD=true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
         "Detekt",
         "Devoxx",
         "Donát",
+        "dotgithub",
         "FOSDEM",
         "gradleinc",
         "gradleup",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,13 @@
 {
     "cSpell.words": [
+        "Alajemba",
+        "Atef",
         "autoplay",
         "Buildship",
+        "Chrzanowski",
+        "Chuks",
         "Csikós",
+        "Detekt",
         "Devoxx",
         "Donát",
         "FOSDEM",
@@ -12,17 +17,21 @@
         "gsoc",
         "Hackathon",
         "Hacktoberfest",
+        "Jakub",
         "Kassovic",
         "Kotest",
+        "Ktlint",
         "Mentees",
         "mkdocs",
         "Multiplatform",
         "Multirepo",
         "Nenashev",
+        "Nouran",
         "Oleg",
         "Packt",
         "Ranjan",
         "Tanish",
-        "Vladimirov"
+        "Vladimirov",
+        "Yongjun"
     ]
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -81,10 +81,6 @@ you can run the `build` and the `serve` commands with the `FULL_BUILD=false` var
 FULL_BUILD=false mkdocs serve
 ```
 
-### Building the Cookbook PDF
-
-Run `BUILD_PDF=1 mkdocs build` to generate the PDF file in [_site/pdf/cookbook.pdf](./../_site/pdf/cookbook.pdf).
-
 ## CI/CD
 
 This site is built and deployed by GitHub Actions,

--- a/docs/contributing/documentation/README.md
+++ b/docs/contributing/documentation/README.md
@@ -31,7 +31,7 @@ and see the slides below.
 - [Gradle Cookbook](https://cookbook.gradle.org/) - a collection of recipes, guides and examples for the Gradle Build Tool.
     - This is an additional solution-based documentation
     - Implementation: MkDocs + Material for MkDocs
-    - [Contributor Guide](../../cookbook/CONTRIBUTING.md)
+    - [Contributor Guide](https://cookbook.gradle.org/CONTRIBUTING/)
 - Plugin documentation - Documentation for the key plugins is provided by the Gradle Build Tool repo.
   For other plugins, see their repositories for the docs and contributing guidelines.
     - Implementation: most plugins use simple documentation pages in GitHub-flavored Markdown (`README.md`).

--- a/docs/events/gsoc/2024/README.md
+++ b/docs/events/gsoc/2024/README.md
@@ -15,12 +15,12 @@ We started with 3 projects, but two of them didn't pass the midterm evaluation.
 
 Completed projects:
 
-- [Gradle Build Server – support for Android projects](./2024/gradle-build-server-android.md) by Tanish Ranjan
+- [Gradle Build Server – support for Android projects](./gradle-build-server-android.md) by Tanish Ranjan
 
 Aborted projects:
 
-- [Gradle Build Server - DevX and Language Support in Buildship](./2024/gradle-build-server-devx.md) by Sidhaarth Saraswathi Ramalingam
-- [Declarative Syntax and Enhancements for the Checkstyle Plugin](./2024/checkstyle-plugin.md) by Hongjie (Jay) Wei
+- [Gradle Build Server - DevX and Language Support in Buildship](./gradle-build-server-devx.md) by Sidhaarth Saraswathi Ramalingam
+- [Declarative Syntax and Enhancements for the Checkstyle Plugin](./checkstyle-plugin.md) by Hongjie (Jay) Wei
 
 ### Mid-Term Project Demos
 

--- a/docs/events/gsoc/2025/configuration-cache-and-lock-contention.md
+++ b/docs/events/gsoc/2025/configuration-cache-and-lock-contention.md
@@ -1,0 +1,11 @@
+# GSoC 2025 - Improving Configuration Cache and lock contention in key Gradle plugins
+
+!!! note "Work in progress"
+
+    This page is under construction as it is the community bonding phase for GSoC.
+    Check it out a bit later!
+    For now, all the information is available on the main page and in the referenced resources and communication channels.
+
+## References
+
+- [Project Page on the GSoC site](https://summerofcode.withgoogle.com/programs/2025/projects/chp2Sbei)

--- a/docs/events/gsoc/2025/jenkins-plugins-toolchain.md
+++ b/docs/events/gsoc/2025/jenkins-plugins-toolchain.md
@@ -1,0 +1,12 @@
+# GSoC 2025 - Gradle Convention Plugin for Developing Jenkins Plugins
+
+!!! note "Work in progress"
+
+    This page is under construction as it is the community bonding phase for GSoC.
+    Check it out a bit later!
+    For now, all the information is available on the main page and in the referenced resources and communication channels.
+
+
+## References
+
+- [Project Page on the GSoC site](https://summerofcode.withgoogle.com/programs/2025/projects/3ujOIGDx)

--- a/docs/events/gsoc/2025/kotlin-code-quality-with-problems-api.md
+++ b/docs/events/gsoc/2025/kotlin-code-quality-with-problems-api.md
@@ -1,0 +1,12 @@
+# GSoC 2025 - Enhanced Kotlin Code Quality Reporting with Gradle Problems API: Integration with Detekt and Ktlint
+
+!!! note "Work in progress"
+
+    This page is under construction as it is the community bonding phase for GSoC.
+    Check it out a bit later!
+    For now, all the information is available on the main page and in the referenced resources and communication channels.
+
+
+## References
+
+- [Project page on the GSoC site](https://summerofcode.withgoogle.com/programs/2025/projects/4UqgKDMe)

--- a/docs/events/gsoc/2025/maven-central-publishing-with-new-api.md
+++ b/docs/events/gsoc/2025/maven-central-publishing-with-new-api.md
@@ -1,0 +1,12 @@
+# GSoC 2025 - Maven Central publishing plugin for Gradle with new APIs
+
+!!! note "Work in progress"
+
+    This page is under construction as it is the community bonding phase for GSoC.
+    Check it out a bit later!
+    For now, all the information is available on the main page and in the referenced resources and communication channels.
+
+
+## References
+
+- [Project Page on the GSoC website](https://summerofcode.withgoogle.com/programs/2025/projects/zCRWjfpd)

--- a/docs/events/gsoc/2025/project-ideas.md
+++ b/docs/events/gsoc/2025/project-ideas.md
@@ -1,0 +1,83 @@
+# GSoC 2025 - Project Ideas
+
+This is an archive of the 2025 project ideas about Gradle.
+The projects were published in the Kotlin Foundation,
+see the list [here](https://kotlinlang.org/docs/gsoc-2025.html).
+
+### 🔍 Clean and actionable reporting for Gradle code quality plugins for Kotlin
+
+Gradle recently introduced a new [Problems API](https://docs.gradle.org/current/userguide/reporting_problems.html)  that allows Gradle and third-party plugins to propagate issues and warnings in a unified way. This API provides clean and actionable error reporting and more insights into the console output, dedicated HTML reports, and connected observability tools. IDEs such as IntelliJ IDEA or Android Studio also have access to the details via Gradle’s tool integration API, and can show warnings right in the code editor. Several core features and plugins have already adopted the Problems API: Java compilation, dependency resolution errors, deprecation warnings, etc. We want the code quality plugins for Kotlin to adopt this API, too; it would greatly improve the developer experience for 100,000+ Kotlin developers using Gradle. 
+
+In this project, we invite contributors to choose a number of Kotlin code quality plugins, such as Ktlint, Detekt, Diktat, ArchUnit, or Checkstyle for Kotlin, and integrate them with Problems API. You can also work on integrating a similar analysis for Gradle builds defined with KotlinDSL. 
+
+* Complexity: Easy or Medium, 90 hrs or 175 hrs  
+* Deliverables: Implement Problems API integration in the mentioned plugins  
+* Skills to improve: Kotlin, Gradle  
+* Potential Mentors: Oleg Nenashev, Balint Hegyi, Reinhold Degenfellner
+
+### 📦 Maven Central publishing plugin for Gradle with new APIs
+
+[Maven Central](https://central.sonatype.com/) is one of the most popular Maven repositories for publishing JVM-focused libraries and projects. It is actively used by Apache Maven or Gradle-based open-source projects, and based on Sonatype Nexus v2, pending migration to a newer version. There is ongoing migration of open source projects to a new Maven Central Instance, which has a very different API implementation and needs special support in the build tool plugins. Developing a Gradle plugin that is compatible with the new Maven Central publication APIs would help the library authors building with Gradle to have a smooth experience with the new process.
+
+Currently there are multiple implementations of Maven Central publishing plugins in Gradle, e.g. the [Maven Publish Plugin](https://docs.gradle.org/current/userguide/publishing_maven.html) or the [New Maven Central Publishing](https://github.com/GradleUp/nmcp) which already tries to adopt the new APIs . A potential contributor, during the application or the community bonding phase, would need to review the implementations and suggest a plugin to be updated, or decide to build a new plugin / fork. The deliverables would include either a new version of an existing plugin for Maven Central publishing or a new plugin for Gradle. We anticipate the implementation to be in Kotlin or Java and to have proper test coverage and documentation. Additional deliverables may include Kotlin DSL extensions to simplify usage of the plugins and [Declarative Gradle](https://declarative.gradle.org/) extensions.
+
+* Complexity: Easy to Medium, 90 hrs to 175 hrs  
+* Deliverables: updated Maven Central publishing plugin or a new plugin  
+* Skills to improve: Kotlin, Gradle, Maven Repositories  
+* Potential Mentors: Gradle team, respective plugin maintainers
+
+### 🚅 Improving Configuration Cache and lock contention in key Gradle plugins 
+
+Gradle is working on [Isolated Projects](https://docs.gradle.org/current/userguide/isolated_projects.html) \- a new feature that greatly extends the configuration cache to further improve performance, particularly the performance of Android Studio and Intellij IDEA sync. From the developer experience standpoint, it is one of the most anticipated features in Gradle.
+
+One of the problems for Isolated projects is the lock contention in the Gradle core and plugins sometimes getting in the way of parallel execution. We would like to reduce the lock contention, especially in the key Gradle Build Tool plugins for Java, Kotlin, Android and Kotlin Multiplatform ecosystems. Contributors are welcome to choose the deliverables, based on their interest and the desired project size. Potential deliverables include but not limited to:
+
+* Embed the [Configuration Cache Report](https://github.com/gradle/configuration-cache-report) tool into the Gradle Profiler (or "implement a GitHub Action for it"?)  
+* Profile Gradle and a few popular Gradle plugins in various projects, with automation of the test suite on GHA  
+* Determine potential areas and plugins where lock contention can be reduced, with or without Configuration Cache  
+* While around, contribute to other areas of [Configuration Cache compatibility](https://github.com/gradle/gradle/issues/13490) in the target plugins  
+* Implement some of the discovered improvements
+
+Summary: 
+
+* Complexity: Easy to Large, 90 hrs to 350 hrs  
+* Deliverables: Implementing extensibility features in the Kotlin DSL for Gradle and improving support for common project integrations  
+* Skills to improve: Kotlin, Gradle, Java, Performance Analysis, Profiling  
+* Potential Mentors: Oleg Nenashev, Laura Kassovic
+
+### 🔌 Gradle Convention plugin for developing Jenkins Plugins
+
+There are more than 50 Jenkins plugins that are implemented with Gradle. There is a [Gradle JPI plugin](https://github.com/jenkinsci/gradle-jpi-plugin) but it is not fully compliant with Jenkins hosting requirements, and needs an update. In this project idea, the aim would be to recover the Gradle developer flow for Jenkins, reach feature parity with the Apache Maven flow ([Parent POM](https://github.com/jenkinsci/plugin-pom), [Plugin Compatibility Tester](https://github.com/jenkinsci/plugin-compat-tester), [Jenkins Bill of Materials](https://github.com/jenkinsci/bom), etc.) and to improve the developer experience for those who develop Jenkins plugins with Gradle.
+
+Contributors are welcome to choose the deliverables, based on their interest and the desired project size. Potential deliverables include but not limited to:
+
+* Refreshing the Gradle JPI plugin and making it compliant with hosting best practices
+* Migrating the Gradle JPI plugin codebase from Groovy to Kotlin
+* Implementing a new convention plugin for Jenkins Plugins that would cover the main features of Jenkins plugin Parent POM, with Kotlin and Kotlin DSL. This would include not just building the plugin, but also testing and static analysis according to Jenkins’ best practices
+* Adopting the refreshed plugin and/or the convention plugin in the most popular Gradle plugin, including the Gradle Plugin itself
+* Integrating Gradle Plugins into Plugin Compatibility Tester and Bill of Materials
+* Documenting the updated Gradle development flow for Jenkins plugins
+
+Summary:
+
+* Complexity: Easy to Large, 90 hrs or 350 hrs
+* Deliverables: Updated Gradle JPI Plugin AND/OR new convention plugin for Jenkins, published on Jenkins Update Center and Gradle Plugin Portal
+* Skills to improve: Kotlin DSL, Kotlin, Gradle, Jenkins, Java
+* Potential Mentors: Oleg Nenashev, Stefan Wolf
+
+### 📓 Kotlin DSL documentation samples test framework
+
+Many projects, including Gradle, have a lot of Kotlin DSL samples and code snippets (see the Gradle Docs for examples). Testing them against multiple versions poses certain challenges because the snippets often represent incomplete code for the sake of brevity. We would like to build a test framework that simplifies the verification of those samples within a unit test framework (Kotest or JUnit 5) on GitHub Actions and Teamcity.
+
+* Complexity: Easy or Medium, 90 hrs or 175 hrs
+* Deliverables: Implementing extensibility features in the Kotlin DSL for Gradle and improving support for common project integrations
+* Skills to improve: Kotlin, Gradle, Java, Static Analysis
+* Potential Mentors: Oleg Nenashev
+
+### 🔌 IntelliJ Platform Gradle Plugin – Gradle Reporting and Parallel Verifications
+
+The IntelliJ Platform Gradle Plugin, a plugin for the Gradle build system, simplifies configuring your environment for building, testing, verifying, and publishing plugins for IntelliJ-based IDEs. The plugin manages the build, test, and verification steps while keeping up with the constant changes introduced in the IntelliJ Platform. The IntelliJ Platform Gradle Plugin is used by JetBrains, third-party developers, and external companies to integrate their workflows with JetBrains tools.
+
+* Complexity: Medium, 175 hrs
+* Skills to improve: Kotlin, Gradle, IntelliJ Platform
+* Potential Mentors: Jakub Chrzanowski, JetBrains

--- a/docs/events/gsoc/README.md
+++ b/docs/events/gsoc/README.md
@@ -13,85 +13,18 @@ Gradle has participated in GSoC since 2023.
 
 ## GSoC 2025
 
-In 2025, we plan to participate under the umbrella of the [Kotlin Foundation](https://kotlinfoundation.org/).
-There might be related projects in other mentoring organizations.
+In 2025, we participate under the umbrella of the [Kotlin Foundation](https://kotlinfoundation.org/).
+There might be also related projects in other mentoring organizations.
 
-### Project Ideas
+### Projects
 
-#### 🐛🔍 Clean and actionable reporting for Gradle code quality plugins for Kotlin
+In the Kotlin Foundation, we have the following Gradle focused projects this year:
 
-Gradle recently introduced a new [Problems API](https://docs.gradle.org/current/userguide/reporting_problems.html)  that allows Gradle and third-party plugins to propagate issues and warnings in a unified way. This API provides clean and actionable error reporting and more insights into the console output, dedicated HTML reports, and connected observability tools. IDEs such as IntelliJ IDEA or Android Studio also have access to the details via Gradle’s tool integration API, and can show warnings right in the code editor. Several core features and plugins have already adopted the Problems API: Java compilation, dependency resolution errors, deprecation warnings, etc. We want the code quality plugins for Kotlin to adopt this API, too; it would greatly improve the developer experience for 100,000+ Kotlin developers using Gradle. 
-
-In this project, we invite contributors to choose a number of Kotlin code quality plugins, such as Ktlint, Detekt, Diktat, ArchUnit, or Checkstyle for Kotlin, and integrate them with Problems API. You can also work on integrating a similar analysis for Gradle builds defined with KotlinDSL. 
-
-* Complexity: Easy or Medium, 90 hrs or 175 hrs  
-* Deliverables: Implement Problems API integration in the mentioned plugins  
-* Skills to improve: Kotlin, Gradle  
-* Potential Mentors: Oleg Nenashev, Balint Hegyi, Reinhold Degenfellner
-
-#### 📦 Maven Central publishing plugin for Gradle with new APIs
-
-[Maven Central](https://central.sonatype.com/) is one of the most popular Maven repositories for publishing JVM-focused libraries and projects. It is actively used by Apache Maven or Gradle-based open-source projects, and based on Sonatype Nexus v2, pending migration to a newer version. There is ongoing migration of open source projects to a new Maven Central Instance, which has a very different API implementation and needs special support in the build tool plugins. Developing a Gradle plugin that is compatible with the new Maven Central publication APIs would help the library authors building with Gradle to have a smooth experience with the new process.
-
-Currently there are multiple implementations of Maven Central publishing plugins in Gradle, e.g. the [Maven Publish Plugin](https://docs.gradle.org/current/userguide/publishing_maven.html) or the [New Maven Central Publishing](https://github.com/GradleUp/nmcp) which already tries to adopt the new APIs . A potential contributor, during the application or the community bonding phase, would need to review the implementations and suggest a plugin to be updated, or decide to build a new plugin / fork. The deliverables would include either a new version of an existing plugin for Maven Central publishing or a new plugin for Gradle. We anticipate the implementation to be in Kotlin or Java and to have proper test coverage and documentation. Additional deliverables may include Kotlin DSL extensions to simplify usage of the plugins and [Declarative Gradle](https://declarative.gradle.org/) extensions.
-
-* Complexity: Easy to Medium, 90 hrs to 175 hrs  
-* Deliverables: updated Maven Central publishing plugin or a new plugin  
-* Skills to improve: Kotlin, Gradle, Maven Repositories  
-* Potential Mentors: Gradle team, respective plugin maintainers
-
-#### 🚅 Improving Configuration Cache and lock contention in key Gradle plugins 
-
-Gradle is working on [Isolated Projects](https://docs.gradle.org/current/userguide/isolated_projects.html) \- a new feature that greatly extends the configuration cache to further improve performance, particularly the performance of Android Studio and Intellij IDEA sync. From the developer experience standpoint, it is one of the most anticipated features in Gradle.
-
-One of the problems for Isolated projects is the lock contention in the Gradle core and plugins sometimes getting in the way of parallel execution. We would like to reduce the lock contention, especially in the key Gradle Build Tool plugins for Java, Kotlin, Android and Kotlin Multiplatform ecosystems. Contributors are welcome to choose the deliverables, based on their interest and the desired project size. Potential deliverables include but not limited to:
-
-* Embed the [Configuration Cache Report](https://github.com/gradle/configuration-cache-report) tool into the Gradle Profiler (or "implement a GitHub Action for it"?)  
-* Profile Gradle and a few popular Gradle plugins in various projects, with automation of the test suite on GHA  
-* Determine potential areas and plugins where lock contention can be reduced, with or without Configuration Cache  
-* While around, contribute to other areas of [Configuration Cache compatibility](https://github.com/gradle/gradle/issues/13490) in the target plugins  
-* Implement some of the discovered improvements
-
-Summary: 
-
-* Complexity: Easy to Large, 90 hrs to 350 hrs  
-* Deliverables: Implementing extensibility features in the Kotlin DSL for Gradle and improving support for common project integrations  
-* Skills to improve: Kotlin, Gradle, Java, Performance Analysis, Profiling  
-* Potential Mentors: Oleg Nenashev, Laura Kassovic
-
-#### 🔌 Gradle Convention plugin for developing Jenkins Plugins
-
-There are more than 50 Jenkins plugins that are implemented with Gradle. There is a [Gradle JPI plugin](https://github.com/jenkinsci/gradle-jpi-plugin) but it is not fully compliant with Jenkins hosting requirements, and needs an update. In this project idea, the aim would be to recover the Gradle developer flow for Jenkins, reach feature parity with the Apache Maven flow ([Parent POM](https://github.com/jenkinsci/plugin-pom), [Plugin Compatibility Tester](https://github.com/jenkinsci/plugin-compat-tester), [Jenkins Bill of Materials](https://github.com/jenkinsci/bom), etc.) and to improve the developer experience for those who develop Jenkins plugins with Gradle.
-
-Contributors are welcome to choose the deliverables, based on their interest and the desired project size. Potential deliverables include but not limited to:
-
-* Refreshing the Gradle JPI plugin and making it compliant with hosting best practices  
-* Migrating the Gradle JPI plugin codebase from Groovy to Kotlin   
-* Implementing a new convention plugin for Jenkins Plugins that would cover the main features of Jenkins plugin Parent POM, with Kotlin and Kotlin DSL. This would include not just building the plugin, but also testing and static analysis according to Jenkins’ best practices  
-* Adopting the refreshed plugin and/or the convention plugin in the most popular Gradle plugin, including the Gradle Plugin itself  
-* Integrating Gradle Plugins into Plugin Compatibility Tester and Bill of Materials  
-* Documenting the updated Gradle development flow for Jenkins plugins
-
-Summary: 
-
-* Complexity: Easy to Large, 90 hrs or 350 hrs  
-* Deliverables: Updated Gradle JPI Plugin AND/OR new convention plugin for Jenkins, published on Jenkins Update Center and Gradle Plugin Portal  
-* Skills to improve: Kotlin DSL, Kotlin, Gradle, Jenkins, Java  
-* Potential Mentors: Oleg Nenashev, Stefan Wolf
-
-#### 📓 Kotlin DSL documentation samples test framework
-
-Many projects, including Gradle, have a lot of Kotlin DSL samples and code snippets (see the Gradle Docs for examples). Testing them against multiple versions poses certain challenges because the snippets often represent incomplete code for the sake of brevity. We would like to build a test framework that simplifies the verification of those samples within a unit test framework (Kotest or JUnit 5) on GitHub Actions and Teamcity.
-
-* Complexity: Easy or Medium, 90 hrs or 175 hrs
-* Deliverables: Implementing extensibility features in the Kotlin DSL for Gradle and improving support for common project integrations
-* Skills to improve: Kotlin, Gradle, Java, Static Analysis
-* Potential Mentors: Oleg Nenashev
-
-#### Suggest your own project idea!
-
-Original project ideas are welcome!
-If you are interested, make a suggestion on our Slack channel (see below).
+- [Gradle Convention Plugin for Developing Jenkins Plugins](./2025/jenkins-plugins-toolchain.md) by Aarav Mahajan
+- [Improving Configuration Cache and lock contention in key Gradle plugins](./2025/configuration-cache-and-lock-contention.md) by Nouran Atef
+- [Enhanced Kotlin Code Quality Reporting with Gradle Problems API: Integration with Detekt and Ktlint](./2025/kotlin-code-quality-with-problems-api.md) by Vanessa Johnson
+- [Maven Central publishing plugin for Gradle with new APIs](./2025/maven-central-publishing-with-new-api.md) by Yongjun Hong
+- [IntelliJ Platform Gradle Plugin – Gradle Reporting and Parallel Verifications](https://summerofcode.withgoogle.com/programs/2025/projects/lJoAo8B7) by Victoria Chuks Alajemba
 
 ## Communication channels
 
@@ -145,9 +78,11 @@ References:
 
 ## Archive
 
+### Project Ideas
+
+- [GSoC 2025 project ideas](./2025/project-ideas.md)
+
 ### Previous Years
 
 - [GSoC 2024](./2024/README.md) - 3 Projects
 - [GSoC 2023](./2023/README.md) - 1 projects
-
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -172,9 +172,6 @@ plugins:
           - name: gradle-profiler
             import_url: 'https://github.com/gradle/gradle-profiler?branch=master&edit_uri=/blob/master/'
             imports: [ "README.md" ]
-          - name: declarative-gradle
-            import_url: 'https://github.com/gradle/declarative-gradle?branch=main&edit_uri=/blob/main/'
-            imports: [ "README.md", "**/README.md" ]
           - name: github-actions
             import_url: 'https://github.com/gradle/actions?branch=main&edit_uri=/blob/main/'
             imports: [ "README.md", "*" ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,17 +118,23 @@ nav:
     - Code of Conduct: dotgithub/CODE_OF_CONDUCT.md
   - Events:
       - Events Overview: events/README.md
-      - 2024 Developer Survey: surveys/developer-survey/README.md
-      - Hacktoberfest: events/hacktoberfest/README.md
       - Google Summer of Code:
         - Overview: events/gsoc/README.md
+        - 2025 projects:
+          - Convention Plugin for developing Jenkins Plugins: events/gsoc/2025/jenkins-plugins-toolchain.md
+          - Improving Configuration Cache and lock contention in key plugins: events/gsoc/2025/configuration-cache-and-lock-contention.md
+          - Kotlin Code Quality Reporting with Problems API: events/gsoc/2025/kotlin-code-quality-with-problems-api.md
+          - Maven Central publishing for Gradle with new APIs: events/gsoc/2025/maven-central-publishing-with-new-api.md
         - Archive:
+          - GSoC 2025 Project Ideas: events/gsoc/2025/project-ideas.md
           - GSoC 2024:
             - Summary: events/gsoc/2024/README.md
             - Gradle Build Server - Support for Android projects: events/gsoc/2024/gradle-build-server-android.md
             - Gradle Build Server - DevX and Language Support in Buildship: events/gsoc/2024/gradle-build-server-devx.md
             - Declarative Syntax and Enhancements for the Checkstyle Plugin: events/gsoc/2024/checkstyle-plugin.md
           - GSoC 2023: events/gsoc/2023/README.md
+      - Hacktoberfest: events/hacktoberfest/README.md
+      - 2024 Developer Survey: surveys/developer-survey/README.md
   - Resources:
     - Key Resources: resources/README.md
     - Public Roadmap: roadmap/README.md


### PR DESCRIPTION
As discussed at today's meeting, kicking off the 2025 project pages so that all contributors can work on them