### PR TITLE
Remove Gradle Events Calendar

### DIFF
--- a/docs/events/README.md
+++ b/docs/events/README.md
@@ -16,10 +16,6 @@ You can learn about the key upcoming events in [our newsletter](https://newslett
 
 ![Gradle Build Tool team at the DPE Summit 2024](./gallery/2024-DPE-Summit.png)
 
-## Gradle Events Calendar
-
-<iframe src="https://calendar.google.com/calendar/embed?src=c_bef13e2ccec320d388e254a3e245c089002311db88ede9956e1d3d9e9a6ab797%40group.calendar.google.com&ctz=Europe%2FZurich" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-
 ## Mentorship Programs
 
 In Gradle, we participate in mentorship programs


### PR DESCRIPTION
As. discussed with @lkasso , we currently have no bandwidth to maintain it