### PR TITLE
Fix capitalization and add evaluation video link and dev.to post

### DIFF
--- a/docs/events/gsoc/2025/kotlin-code-quality-with-problems-api.md
+++ b/docs/events/gsoc/2025/kotlin-code-quality-with-problems-api.md
@@ -28,14 +28,16 @@ Mentors
 - Gradle's Problems API
 
 ## Rationale
-Gradle recently introduced a new Problems API that allows Gradle and third-party plugins to propagate issues and warnings in a unified way. This API provides clean and actionable error reporting and more insights into the console output, dedicated HTML reports, and connected observability tools. We also want the code quality plugins for Kotlin to adopt this API. It would significantly improve the developer experience for 100,000+ Kotlin developers using Gradle. This integration will happen in detekt and ktlint which are 2 popular developer tools.
+Gradle recently introduced a new Problems API that allows Gradle and third-party plugins to propagate issues and warnings in a unified way. This API provides clean and actionable error reporting and more insights into the console output, dedicated HTML reports, and connected observability tools. We also want the code quality plugins for Kotlin to adopt this API. It would significantly improve the developer experience for 100,000+ Kotlin developers using Gradle. This integration will happen in Detekt and Ktlint which are 2 popular developer tools.
 
 ## Achievements
 ### Detekt
-The problems api integration and testing is currently in a PR in Detekt where it has its own separate module where there is a file that feeds the problems api reporter with the detekt issues that may arise in a project. The console report file was created and made available through in a file in the META-INF/services folder by listing the problems api reporter file there. This PR can be found [here](https://github.com/detekt/detekt/pull/8562)
+The Problems API integration and testing is currently in a PR in Detekt where it has its own separate module where there is a file that feeds the problems api reporter with the detekt issues that may arise in a project. The console report file was created and made available through in a file in the META-INF/services folder by listing the Problems API reporter file there. This PR can be found [here](https://github.com/detekt/detekt/pull/8562). A blog post was written about improving Detekt's quality reporting that can be found [here](https://dev.to/gradle-community/enhanced-kotlin-code-quality-reporting-with-the-gradle-problems-api-56bo)
 
 ### Ktlint
-The problems api integration is currently in a PR in Ktlint where a separate file was made to feed the problems api reporter with the ktlint errors that may arise in a project. The problems api reporter is used in the ConsoleReportWorkAction.kt file to report the lint errors found in the project. This PR can be found [here](https://github.com/JLLeitschuh/ktlint-gradle/pull/927)
+The Problems API integration is currently in a PR in Ktlint where a separate file was made to feed the Problems API reporter with the ktlint errors that may arise in a project. The Problems API reporter is used in the ConsoleReportWorkAction.kt file to report the lint errors found in the project. This PR can be found [here](https://github.com/JLLeitschuh/ktlint-gradle/pull/927)
+
+The midterm evaluation video where I talk about why we should integrate the Problems API and issues I ran into half way through can be found [here](https://drive.google.com/file/d/1Eulmey166Whm5me3lq7C0IlywSgT5ubr/view)
 
 ## References
 


### PR DESCRIPTION
Corrected capitalization of 'Problems API' and added a link to a midterm evaluation video discussing integration challenges and the dev.to post